### PR TITLE
Prevent seeking when panning with mouse. There's still potential for …

### DIFF
--- a/src/app/waveform/waveform.component.ts
+++ b/src/app/waveform/waveform.component.ts
@@ -56,6 +56,7 @@ export class WaveformComponent implements OnInit, AfterViewInit, OnDestroy {
   private initialZoom: number;
   private initialDistance: number;
   private zoomOnMouseDown: number;
+  private offsetOnMouseDown: number;
 
   constructor(private audioService: AudioPlayerService,
               private piperService: FeatureExtractionService,
@@ -639,10 +640,15 @@ export class WaveformComponent implements OnInit, AfterViewInit, OnDestroy {
 
   seekStart(): void {
     this.zoomOnMouseDown = this.timeline.timeContext.zoom;
+    this.offsetOnMouseDown = this.timeline.timeContext.offset;
   }
 
   seekEnd(x: number): void {
-    if (this.zoomOnMouseDown === this.timeline.timeContext.zoom) {
+    const hasSameZoom: boolean = this.zoomOnMouseDown ===
+      this.timeline.timeContext.zoom;
+    const hasSameOffset: boolean = this.offsetOnMouseDown ===
+      this.timeline.timeContext.offset;
+    if (hasSameZoom && hasSameOffset) {
       this.seek(x);
     }
   }


### PR DESCRIPTION
…this approach to go wrong, for both zooming and panning. During the duration of the click, if the offset or zoom are returned to the starting position, the mouse will seek to its current x position.