### PR TITLE
Fix/slow streaming

### DIFF
--- a/src/app/services/feature-extraction/FeatureReducers.ts
+++ b/src/app/services/feature-extraction/FeatureReducers.ts
@@ -1,0 +1,63 @@
+/**
+ * Created by lucast on 26/04/2017.
+ */
+import {StreamingResponse} from 'piper/StreamingService';
+import {Feature} from 'piper/Feature';
+import {SampleType} from 'piper';
+
+export const arrayReducer = <T>(acc: T[], val: T[]): T[] => {
+  acc.push.apply(acc, val);
+  return acc;
+};
+
+export const typedArrayReducer = (acc: Float32Array,
+                                  val: Float32Array): Float32Array => {
+  return Float32Array.of(...acc, ...val);
+};
+
+const inPlaceTypedArrayReducer = (acc: Float32Array,
+                                  val: Float32Array,
+                                  i: number): Float32Array => {
+  acc.set(val, i);
+  return acc;
+};
+
+export const streamingResponseReducer = (acc: StreamingResponse,
+                                         val: StreamingResponse,
+                                         i: number): StreamingResponse => {
+  acc.processedBlockCount = val.processedBlockCount;
+  if (acc.features.data instanceof Array &&
+    val.features.data instanceof Array) {
+    acc.features.data = arrayReducer<Feature>(
+      acc.features.data,
+      val.features.data
+    );
+  } else if (acc.features.data instanceof Float32Array &&
+    val.features.data instanceof Float32Array) {
+    const isOneSamplePerStep = acc.outputDescriptor.configured.sampleType ===
+      SampleType.OneSamplePerStep;
+    if (isOneSamplePerStep) {
+      // for one sample per step vectors we know there will be totalBlockCount
+      // number of samples - so pre-allocate the Float32Array when we know
+      // the totalBlockCount (after receiving the first feature)
+      if ( i === 1  ) {
+        const newBlock = new Float32Array(acc.totalBlockCount);
+        newBlock[0] = acc.features.data[0];
+        acc.features.data = newBlock;
+      }
+      acc.features.data = inPlaceTypedArrayReducer(
+        acc.features.data,
+        val.features.data,
+        i
+      );
+    } else { // if not OneSamplePerStep we have to make a new array each time
+      acc.features.data = typedArrayReducer(
+        acc.features.data,
+        val.features.data
+      );
+    }
+  } else {
+    throw new Error('Invalid feature output. Aborting');
+  }
+  return acc;
+};

--- a/src/app/services/feature-extraction/feature-extraction.service.ts
+++ b/src/app/services/feature-extraction/feature-extraction.service.ts
@@ -66,38 +66,12 @@ export class FeatureExtractionService {
   }
 
   extract(analysisItemId: string, request: SimpleRequest): Promise<void> {
-    const arrayReducer = (acc, val) => {
-      acc.push.apply(acc, val);
-      return acc;
-    };
-    const typedArrayReducer = (acc: Float32Array,
-                               val: Float32Array): Float32Array => {
-      return Float32Array.of(...acc, ...val);
-    };
     return this.client.collect(request)
       .do(val => {
         this.progressUpdated.next({
           id: analysisItemId,
           value: (val.processedBlockCount / val.totalBlockCount) * 100
         });
-      })
-      .reduce((acc, val) => {
-        if (acc.features.data instanceof Array &&
-          val.features.data instanceof Array) {
-          acc.features.data = arrayReducer(
-            acc.features.data,
-            val.features.data
-          );
-        } else if (acc.features.data instanceof Float32Array &&
-          val.features.data instanceof Float32Array) {
-          acc.features.data = typedArrayReducer(
-            acc.features.data,
-            val.features.data
-          );
-        } else {
-          throw new Error('Invalid feature output. Aborting');
-        }
-        return acc;
       })
       .toPromise()
       .then((response) => {


### PR DESCRIPTION
Combine the features on the server instead of the client. Emit less messages back to the client, to prevent swamping the browser's event queue, by filtering the responses by an increase in at least 1 percentage point.