### PR TITLE
Fix/mobile safari high water

### DIFF
--- a/src/app/feature-extraction-menu/feature-extraction-menu.component.ts
+++ b/src/app/feature-extraction-menu/feature-extraction-menu.component.ts
@@ -80,7 +80,10 @@ export class FeatureExtractionMenuComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.piperService.list().then(this.populateExtractors);
+    this.piperService.list().then(this.populateExtractors).then(() => {
+      this.piperService.load('pyin');
+      this.piperService.load('nnls-chroma');
+    });
     this.librariesUpdatedSubscription =
       this.piperService.librariesUpdated$.subscribe(this.populateExtractors);
   }

--- a/src/app/feature-extraction-menu/feature-extraction-menu.component.ts
+++ b/src/app/feature-extraction-menu/feature-extraction-menu.component.ts
@@ -82,7 +82,7 @@ export class FeatureExtractionMenuComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.piperService.list().then(this.populateExtractors).then(() => {
       this.piperService.load('pyin');
-      this.piperService.load('nnls-chroma');
+      // this.piperService.load('nnls-chroma');
     });
     this.librariesUpdatedSubscription =
       this.piperService.librariesUpdated$.subscribe(this.populateExtractors);

--- a/src/app/feature-extraction-menu/feature-extraction-menu.component.ts
+++ b/src/app/feature-extraction-menu/feature-extraction-menu.component.ts
@@ -80,12 +80,9 @@ export class FeatureExtractionMenuComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.piperService.list().then(this.populateExtractors).then(() => {
-      this.piperService.load('pyin');
-      // this.piperService.load('nnls-chroma');
-    });
     this.librariesUpdatedSubscription =
       this.piperService.librariesUpdated$.subscribe(this.populateExtractors);
+    this.piperService.list().then(this.populateExtractors);
   }
 
   extract(combinedKey: string): void {
@@ -97,9 +94,7 @@ export class FeatureExtractionMenuComponent implements OnInit, OnDestroy {
   }
 
   load(): void {
-    this.piperService.updateAvailableLibraries().subscribe(res => {
-      Object.keys(res).forEach(key => this.piperService.load(key));
-    });
+    this.piperService.updateAvailableLibraries();
   }
 
   ngOnDestroy(): void {

--- a/src/app/services/feature-extraction/FeatureExtractionWorker.ts
+++ b/src/app/services/feature-extraction/FeatureExtractionWorker.ts
@@ -111,7 +111,10 @@ export default class FeatureExtractionWorker {
   constructor(workerScope: DedicatedWorkerGlobalScope,
               private requireJs: RequireJs) {
     this.workerScope = workerScope;
-    this.remoteLibraries = new Map<LibraryKey, LibraryUri>();
+    this.remoteLibraries = new Map<LibraryKey, LibraryUri>([
+      ['nnls-chroma', 'assets/extractors/NNLSChroma.js'],
+      ['pyin', 'assets/extractors/PYin.umd.js'],
+    ]);
     this.service = new ThrottledReducingAggregateService();
     this.setupImportLibraryListener();
     this.server = new WebWorkerStreamingServer(
@@ -124,6 +127,7 @@ export default class FeatureExtractionWorker {
 
     this.workerScope.onmessage = (ev: MessageEvent) => {
       const sendResponse = (result) => {
+        console.warn(ev.data.method);
         this.workerScope.postMessage({
           method: ev.data.method,
           result: result

--- a/src/app/services/feature-extraction/FeatureExtractionWorker.ts
+++ b/src/app/services/feature-extraction/FeatureExtractionWorker.ts
@@ -37,10 +37,10 @@ class AggregateStreamingService implements StreamingService {
 
   constructor() {
     this.services = new Map<LibraryKey, PiperStreamingService>();
-    this.services.set(
-      'vamp-example-plugins',
-      new PiperStreamingService(new PiperVampService(VampExamplePlugins()))
-    );
+    // this.services.set(
+    //   'vamp-example-plugins',
+    //   new PiperStreamingService(new PiperVampService(VampExamplePlugins()))
+    // );
   }
 
   addService(key: LibraryKey, service: PiperStreamingService): void {
@@ -112,7 +112,7 @@ export default class FeatureExtractionWorker {
               private requireJs: RequireJs) {
     this.workerScope = workerScope;
     this.remoteLibraries = new Map<LibraryKey, LibraryUri>([
-      ['nnls-chroma', 'assets/extractors/NNLSChroma.js'],
+      // ['nnls-chroma', 'assets/extractors/NNLSChroma.js'],
       ['pyin', 'assets/extractors/PYin.umd.js'],
     ]);
     this.service = new ThrottledReducingAggregateService();

--- a/src/app/services/feature-extraction/feature-extraction.service.ts
+++ b/src/app/services/feature-extraction/feature-extraction.service.ts
@@ -8,7 +8,7 @@ import {
 } from 'piper/HigherLevelUtilities';
 import {Subject} from 'rxjs/Subject';
 import {Observable} from 'rxjs/Observable';
-import {Http, Response} from '@angular/http';
+import {Http} from '@angular/http';
 import {
   countingIdProvider,
   WebWorkerStreamingClient
@@ -63,7 +63,10 @@ export class FeatureExtractionService {
   }
 
   list(): Promise<ListResponse> {
-    return this.client.list({});
+    return this.client.list({}).then(response => {
+      this.librariesUpdated.next(response);
+      return response;
+    });
   }
 
   extract(analysisItemId: string, request: SimpleRequest): Promise<void> {
@@ -87,20 +90,16 @@ export class FeatureExtractionService {
     });
   }
 
-  updateAvailableLibraries(): Observable<AvailableLibraries> {
-    return this.http.get(this.repositoryUri)
-      .map(res => {
-        const map = res.json();
+  updateAvailableLibraries(): void {
+    this.http.get(this.repositoryUri)
+      .toPromise() // just turn into a promise for now to subscribe / execute
+      .then(res => {
         this.worker.postMessage({
           method: 'addRemoteLibraries',
-          params: map
-        });
-        return map;
+          params: res.json()
+        })
       })
-      .catch((error: Response | any) => {
-        console.error(error);
-        return Observable.throw(error);
-      });
+      .catch(console.error); // TODO Report error to user
   }
 
   load(libraryKey: string): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,10 +391,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -4080,9 +4076,9 @@ piper@piper-audio/piper-js:
   version "0.16.0"
   resolved "https://codeload.github.com/piper-audio/piper-js/tar.gz/e42d0165d93794eeade2b09a345b6123d298f13c"
   dependencies:
-    "@types/base64-js" "^1.2.5"
+    "@types/base64-js" "^1.1.4"
     base64-js "^1.2.0"
-    rxjs "^5.4.0"
+    rxjs "^5.2.0"
 
 portfinder@^1.0.9, portfinder@~1.0.12:
   version "1.0.13"
@@ -4602,20 +4598,11 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"
@@ -6046,16 +6033,9 @@ write-file-atomic@^2.0.0:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
-ws@1.1.1:
+ws@1.1.1, ws@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.1.tgz#082ddb6c641e85d4bb451f03d52f06eabdb1f018"
-  dependencies:
-    options ">=0.0.5"
-    ultron "1.0.x"
-
-ws@^1.0.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"


### PR DESCRIPTION
- AggregateStreamingService previously stored instantiated extractors in a map against the library name, meaning in the case of Emscripten module extractors this used an unnecessary amount of memory (enough to exceed mobile safari's high-water mark and crash the tab). 
  - The map now contains factories / thunks for constructing the extractor, and a new one is created on each list or process request, and thus will be garbage collected after use
- Changed much of the logic in FeatureExtractionWorker and the calling code in feature-extraction.service regarding the importing of libraries.
  - Each library is now loaded sequentially (ensuring only one emscripten module present at a time), its list called, and then when all extractors have been loaded, the aggregated list response is propagated though the various parts of the system eventually resulting in the menu being updated